### PR TITLE
feat: export `elements!` macro

### DIFF
--- a/hypertext/src/html_elements.rs
+++ b/hypertext/src/html_elements.rs
@@ -1,5 +1,6 @@
 //! HTML elements.
 
+#[macro_export]
 macro_rules! elements {
     {
         $(
@@ -25,12 +26,12 @@ macro_rules! elements {
                     $(
                         $(#[$attr_meta])*
                         #[allow(non_upper_case_globals)]
-                        pub const $attr: crate::attributes::Attribute = crate::attributes::Attribute;
+                        pub const $attr: $crate::Attribute = $crate::Attribute;
                     )*
                 )?
             }
 
-            impl crate::attributes::GlobalAttributes for $element {}
+            impl $crate::GlobalAttributes for $element {}
         )*
     }
 }

--- a/hypertext/src/html_elements.rs
+++ b/hypertext/src/html_elements.rs
@@ -1,6 +1,29 @@
 //! HTML elements.
 
 #[macro_export]
+/// Create a set of HTML elements.
+/// Every element is represented as a block containing its attributes.
+///
+/// This macro should be called from within the `html_elements` module.
+///
+/// Example:
+/// ```rust
+/// mod html_elements {
+///    use hypertext::elements;
+///
+///    // Import all existing html elements
+///    pub use hypertext::html_elements::*;
+///
+///    // Define a greeting element which is a custom web component (like the Lit example)
+///    elements! {
+///        /// A custom web component that greets the user.
+///        simple-greeting {
+///            /// The name of the person to greet.
+///            name
+///        }
+///    }
+/// }
+/// ```
 macro_rules! elements {
     {
         $(

--- a/hypertext/src/html_elements.rs
+++ b/hypertext/src/html_elements.rs
@@ -17,7 +17,7 @@
 ///    // Define a greeting element which is a custom web component (like the Lit example)
 ///    elements! {
 ///        /// A custom web component that greets the user.
-///        simple-greeting {
+///        simple_greeting {
 ///            /// The name of the person to greet.
 ///            name
 ///        }


### PR DESCRIPTION
Hello, thank you for this wonderful project.

I was looking into the project's source code when I found the elements! macro and it surprised me that it isn't public as it is quite useful when working with web components.
I've added appropriate documentation and replaced the imports with imports available from outside the crate so this can be used from other crates.

Moving this from #25 because I accidentally created the PR on `main`.