### PR TITLE
Bump axum-core

### DIFF
--- a/hypertext/Cargo.toml
+++ b/hypertext/Cargo.toml
@@ -29,7 +29,7 @@ itoa = { version = "1", optional = true }
 ryu = { version = "1", optional = true }
 
 actix-web = { version = "4", optional = true }
-axum-core = { version = "0.4", optional = true }
+axum-core = { version = "0.5", optional = true }
 http = { version = "1", optional = true }
 
 [features]


### PR DESCRIPTION
The [just-released axum 0.8](https://tokio.rs/blog/2025-01-01-announcing-axum-0-8-0) bumps axum-core to 0.5, all of those are semver-incompatible changes so hypertext's `IntoResponse` impl fails