### PR TITLE
alpinejs feature

### DIFF
--- a/hypertext/Cargo.toml
+++ b/hypertext/Cargo.toml
@@ -45,3 +45,5 @@ actix = ["alloc", "dep:actix-web"]
 poem = ["alloc", "dep:poem"]
 
 htmx = []
+
+alpine-js = []

--- a/hypertext/src/alpine_js.rs
+++ b/hypertext/src/alpine_js.rs
@@ -1,0 +1,41 @@
+#[cfg(feature = "alpine-js")]
+use crate::{Attribute, AttributeNamespace, GlobalAttributes};
+
+/// Attributes for AlpineJs elements.
+///
+/// [AlpineJs Reference](https://alpinejs.dev/)
+#[allow(non_upper_case_globals, clippy::doc_markdown)]
+pub trait AlpineJsAttributes: GlobalAttributes {
+    /// Declare a new Alpine component and its data for a block of HTML
+    const x_data: Attribute = Attribute;
+    /// Dynamically set HTML attributes on an element
+    const x_bind: AttributeNamespace = AttributeNamespace;
+    /// Listen for browser events on an element
+    const x_on: AttributeNamespace = AttributeNamespace;
+    /// Set the text content of an element
+    const x_text: Attribute = Attribute;
+    /// Set the inner HTML of an element
+    const x_html: Attribute = Attribute;
+    /// Synchronize a piece of data with an input element
+    const x_model: Attribute = Attribute;
+    /// Toggle the visibility of an element
+    const x_show: Attribute = Attribute;
+    /// Transition an element in and out using CSS transitions
+    const x_transition: Attribute = Attribute;
+    /// Repeat a block of HTML based on a data set
+    const x_for: Attribute = Attribute;
+    /// Conditionally add/remove a block of HTML from the page entirely
+    const x_if: Attribute = Attribute;
+    /// Run code when an element is initialized by Alpine
+    const x_init: Attribute = Attribute;
+    /// Execute a script each time one of its dependencies change
+    const x_effect: Attribute = Attribute;
+    /// Reference elements directly by their specified keys using the $refs magic property
+    const x_ref: Attribute = Attribute;
+    /// Hide a block of HTML until after Alpine is finished initializing its contents
+    const x_cloak: Attribute = Attribute;
+    /// Prevent a block of HTML from being initialized by Alpine
+    const x_ignore: Attribute = Attribute;
+}
+
+impl<T: GlobalAttributes> AlpineJsAttributes for T {}

--- a/hypertext/src/lib.rs
+++ b/hypertext/src/lib.rs
@@ -101,6 +101,8 @@
 
 #[cfg(feature = "alloc")]
 mod alloc;
+#[cfg(feature = "alpine-js")]
+mod alpine_js;
 mod attributes;
 pub mod html_elements;
 /// HTMX attributes for use with [`maud!`] and [`rsx!`].
@@ -112,6 +114,9 @@ mod web;
 
 #[cfg(feature = "alloc")]
 pub use self::alloc::*;
+/// Use AlpineJs attributes in your HTML elements.
+#[cfg(feature = "alpine-js")]
+pub use self::alpine_js::AlpineJsAttributes;
 pub use self::attributes::{Attribute, AttributeNamespace, GlobalAttributes};
 /// Use HTMX attributes in your HTML elements.
 #[cfg(feature = "htmx")]

--- a/hypertext/tests/main.rs
+++ b/hypertext/tests/main.rs
@@ -1,8 +1,8 @@
 //! Tests for the `hypertext` crate.
 
 use hypertext::{
-    GlobalAttributes, HtmxAttributes, Raw, Renderable, Rendered, html_elements, maud, maud_dyn,
-    maud_move, maud_static, rsx, rsx_dyn, rsx_move, rsx_static,
+    html_elements, maud, maud_dyn, maud_move, maud_static, rsx, rsx_dyn, rsx_move, rsx_static,
+    AlpineJsAttributes, GlobalAttributes, HtmxAttributes, Raw, Renderable, Rendered,
 };
 
 #[test]
@@ -102,6 +102,154 @@ fn htmx() {
             }
             .render(),
             r#"<div><form hx-post="/login" hx-on::after-request="this.reset()"><input type="text" name="username"><input type="password" name="password"><input type="submit" value="Login"></form></div>"#,
+        ),
+    ];
+
+    for (test, expected) in tests {
+        assert_eq!(test, Rendered(expected.to_string()));
+    }
+}
+
+#[test]
+fn alpinejs() {
+    let tests = [
+        (
+            maud! { div x-data="{ open: false }" { "Hello, world!" } }.render(),
+            r#"<div x-data="{ open: false }">Hello, world!</div>"#,
+        ),
+        (
+            rsx! { <div x-data="{ open: false }">"Hello, world!"</div> }.render(),
+            r#"<div x-data="{ open: false }">Hello, world!</div>"#,
+        ),
+        (
+            maud! { div x-bind:class="! open ? 'hidden' : ''" { "Hello, world!" } }.render(),
+            r#"<div x-bind:class="! open ? 'hidden' : ''">Hello, world!</div>"#,
+        ),
+        (
+            rsx! { <div x-bind:class="! open ? 'hidden' : ''">"Hello, world!"</div> }.render(),
+            r#"<div x-bind:class="! open ? 'hidden' : ''">Hello, world!</div>"#,
+        ),
+        (
+            maud! { div x-on:click="open = ! open" { "Hello, world!" } }.render(),
+            r#"<div x-on:click="open = ! open">Hello, world!</div>"#,
+        ),
+        (
+            rsx! { <div x-on:click="open = ! open">"Hello, world!"</div> }.render(),
+            r#"<div x-on:click="open = ! open">Hello, world!</div>"#,
+        ),
+        (
+            maud! { div x-text="new Date().getFullYear()" { "Hello, world!" } }.render(),
+            r#"<div x-text="new Date().getFullYear()">Hello, world!</div>"#,
+        ),
+        (
+            rsx! { <div x-text="new Date().getFullYear()">"Hello, world!"</div> }.render(),
+            r#"<div x-text="new Date().getFullYear()">Hello, world!</div>"#,
+        ),
+        (
+            maud! { div x-html="(await axios.get('/some/html/partial')).data" { "Hello, world!" } }.render(),
+            r#"<div x-html="(await axios.get('/some/html/partial')).data">Hello, world!</div>"#,
+        ),
+        (
+            rsx! { <div x-html="(await axios.get('/some/html/partial')).data">"Hello, world!"</div> }.render(),
+            r#"<div x-html="(await axios.get('/some/html/partial')).data">Hello, world!</div>"#,
+        ),
+        // WARNING: It seems the input element doesn't render consistently and doesn't auto-close
+        (
+            maud! { input type="text" x-model="search" {} }.render(),
+            r#"<input type="text" x-model="search"></input>"#,
+        ),
+        (
+            rsx! { <input type="text" x-model="search" /> }.render(),
+            r#"<input type="text" x-model="search">"#,
+        ),
+        (
+            maud! { div x-show="open" { "Hello, world!" } }.render(),
+            r#"<div x-show="open">Hello, world!</div>"#,
+        ),
+        (
+            rsx! { <div x-show="open">"Hello, world!"</div> }.render(),
+            r#"<div x-show="open">Hello, world!</div>"#,
+        ),
+        (
+            maud! { div x-show="open" x-transition { "Hello, world!" } }.render(),
+            r#"<div x-show="open" x-transition>Hello, world!</div>"#,
+        ),
+        (
+            rsx! { <div x-show="open" x-transition>"Hello, world!"</div> }.render(),
+            r#"<div x-show="open" x-transition>Hello, world!</div>"#,
+        ),
+        (
+            maud! { 
+                template x-for="post in posts" {
+                    h2 x-text="post.title" {}
+                }
+            }.render(),
+            r#"<template x-for="post in posts"><h2 x-text="post.title"></h2></template>"#,
+        ),
+        (
+            rsx! { 
+                <template x-for="post in posts">
+                    <h2 x-text="post.title"></h2>
+                </template>
+            }.render(),
+            r#"<template x-for="post in posts"><h2 x-text="post.title"></h2></template>"#,
+        ),
+        (
+            maud! { 
+                template x-if="open" {
+                    h2 x-text="post.title" {}
+                }
+            }.render(),
+            r#"<template x-if="open"><h2 x-text="post.title"></h2></template>"#,
+        ),
+        (
+            rsx! { 
+                <template x-if="open">
+                    <h2 x-text="post.title"></h2>
+                </template>
+            }.render(),
+            r#"<template x-if="open"><h2 x-text="post.title"></h2></template>"#,
+        ),
+        (
+            maud! { div x-init="date = new Date()" {} }.render(),
+            r#"<div x-init="date = new Date()"></div>"#,
+        ),
+        (
+            rsx! { <div x-init="date = new Date()"></div> }.render(),
+            r#"<div x-init="date = new Date()"></div>"#,
+        ),
+        (
+            maud! { div x-effect="console.log('Count is '+count)" {} }.render(),
+            r#"<div x-effect="console.log('Count is '+count)"></div>"#,
+        ),
+        (
+            rsx! { <div x-effect="console.log('Count is '+count)"></div> }.render(),
+            r#"<div x-effect="console.log('Count is '+count)"></div>"#,
+        ),
+        // WARNING: It seems the input element doesn't render consistently and doesn't auto-close
+        (
+            maud! { input type="text" x-ref="content" {} }.render(),
+            r#"<input type="text" x-ref="content"></input>"#,
+        ),
+        (
+            rsx! { <input type="text" x-ref="content" /> }.render(),
+            r#"<input type="text" x-ref="content">"#,
+        ),
+        (
+            maud! { div x-cloak {} }.render(),
+            r#"<div x-cloak></div>"#,
+        ),
+        (
+            rsx! { <div x-cloak></div> }.render(),
+            r#"<div x-cloak></div>"#,
+        ),
+        (
+            maud! { div x-ignore {} }.render(),
+            r#"<div x-ignore></div>"#,
+        ),
+        (
+            rsx! { <div x-ignore></div> }.render(),
+            r#"<div x-ignore></div>"#,
         ),
     ];
 


### PR DESCRIPTION
Provides a feature set for [AlpineJs](https://alpinejs.dev/) attributes.

Provides tests for every attribute type.

Please look at the note in the tests about `input` inconsistency.

It would be nice to be able to support the [shorthand syntax](https://alpinejs.dev/directives/on#shorthand-syntax) and [global syntax](https://alpinejs.dev/globals/alpine-data) as well, but I don't know how to implement that yet and they aren't mandatory for most of the library.