### PR TITLE
Add Default trait impl for Lazy to enable struct field defaults

### DIFF
--- a/hypertext/src/alloc/mod.rs
+++ b/hypertext/src/alloc/mod.rs
@@ -312,6 +312,13 @@ impl<F: Fn(&mut Buffer<C>), C: Context> Debug for Lazy<F, C> {
     }
 }
 
+impl<C: Context> Default for Lazy<fn(&mut Buffer<C>), C> {
+    #[inline]
+    fn default() -> Lazy<fn(&mut Buffer<C>), C> {
+        Lazy::dangerously_create(|_| ())
+    }
+}
+
 /// A value rendered via its [`Display`] implementation.
 ///
 /// This will handle escaping special characters for you.


### PR DESCRIPTION
Implement Default for Lazy<fn(&mut Buffer<C>), C> to support using `#[derive(Default)]` on structs containing Lazy fields (e.g., for component children).

The default value creates an empty Lazy that renders nothing.