### PR TITLE
fix: don't require downstream bon dependency for components

### DIFF
--- a/crates/hypertext-macros/src/renderable.rs
+++ b/crates/hypertext-macros/src/renderable.rs
@@ -148,6 +148,7 @@ pub fn generate(args: RenderableArgs, mut fn_item: ItemFn) -> syn::Result<TokenS
         .map(|attr| quote!(#attr))
         .collect::<Vec<_>>();
 
+    let is_default_builder = args.builder.is_none() && !fields.is_empty();
     let builder = args.builder.or_else(|| {
         if fields.is_empty() {
             None
@@ -157,9 +158,20 @@ pub fn generate(args: RenderableArgs, mut fn_item: ItemFn) -> syn::Result<TokenS
     });
 
     if let Some(BuilderArg::Path(path)) = builder {
-        struct_attrs.push(quote! {
-            #[derive(#path)]
-        });
+        let derive = if is_default_builder {
+            quote! {
+                #[derive(#path)]
+                #[builder(crate = ::hypertext::bon)]
+            }
+        } else {
+            quote! {
+                #[derive(#path)]
+            }
+        };
+
+        // Need to insert this in the beginning so that any user added
+        // `#[builder(..)]` parameters do not end up before `#[derive(..)]`
+        struct_attrs.insert(0, derive);
     }
 
     let fn_name = &fn_item.sig.ident;


### PR DESCRIPTION
Make the default builder for the `#[renderable]`/`#[component]` macro set the `#[builder(crate = ::hypertext::bon)]` parameter so that projects using the macros do not have to add bon to its own dependencies.

Without the `crate` parameter, the macro will expand to code that directly refereces bon. If the user of the macro does not have bon as a direct dependency it will generate the following error:

```
41 | #[renderable]
   | ^^^^^^^^^^^^^ could not find `bon` in the list of imported crates
```

This adds the `crate` parameter when not setting the builder directly. The DefaultBuilder works without it. But if one was to explicitly set `#[renderable(builder = hypertext::Builder)]` then one can either keep bon as a direct dependency or set the `crate` parameter manually. That should normally not be necessary since `hypertext::Builder` is the default builder.